### PR TITLE
Add management workload annotations

### DIFF
--- a/helm-charts/application-manager/templates/deployment.yaml
+++ b/helm-charts/application-manager/templates/deployment.yaml
@@ -21,6 +21,8 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: {{ template "application-manager.name" . }}
         component: "application-manager"

--- a/helm-charts/cert-policy-controller/templates/deployment.yaml
+++ b/helm-charts/cert-policy-controller/templates/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: {{ include "controller.name" . }}
         app: {{ include "controller.name" . }}

--- a/helm-charts/iam-policy-controller/templates/iam-policy-controller-deployment.yaml
+++ b/helm-charts/iam-policy-controller/templates/iam-policy-controller-deployment.yaml
@@ -17,6 +17,8 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: {{ template "iamPolicyController.name" . }}
         app: {{ template "iamPolicyController.fullname" . }}

--- a/helm-charts/policy/templates/config_policy_deployment.yaml
+++ b/helm-charts/policy/templates/config_policy_deployment.yaml
@@ -27,6 +27,8 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: {{ template "policy.name" . }}-config-policy
         component: "governance"

--- a/helm-charts/policy/templates/policy_framework_deployment.yaml
+++ b/helm-charts/policy/templates/policy_framework_deployment.yaml
@@ -28,6 +28,8 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: {{ template "policy.name" . }}-framework
         component: "governance"

--- a/helm-charts/search/templates/deployment.yaml
+++ b/helm-charts/search/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
       heritage: {{ .Release.Service }}
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: {{ template "search.name" . }}
         component: "search"

--- a/helm-charts/work-manager/templates/deployment.yaml
+++ b/helm-charts/work-manager/templates/deployment.yaml
@@ -21,6 +21,8 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: {{ template "work-manager.name" . }}
         component: "work-manager"


### PR DESCRIPTION
In support of the workload partitioning feature
(openshift/enhancements#703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.

Signed-off-by: Ian Miller <imiller@redhat.com>