### PR TITLE
Grant the IAM policy controller SA access to query for OpenShift groups

### DIFF
--- a/helm-charts/iam-policy-controller/templates/iam-policy-controller-clusterrole.yaml
+++ b/helm-charts/iam-policy-controller/templates/iam-policy-controller-clusterrole.yaml
@@ -111,3 +111,9 @@ rules:
   - roles
   verbs:
   - list
+- apiGroups:
+  - user.openshift.io
+  resources:
+  - groups
+  verbs:
+  - get


### PR DESCRIPTION
This relates to:
open-cluster-management/backlog#14166
open-cluster-management/iam-policy-controller#66