### PR TITLE
Enable legacy leader election when necessary for the cert controller

### DIFF
--- a/helm-charts/cert-policy-controller/templates/deployment.yaml
+++ b/helm-charts/cert-policy-controller/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
         {{- if .Values.args.defaultDuration }}
         - --default-duration={{ .Values.args.defaultDuration }}
         {{- end }}
+        {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
+        - --legacy-leader-elect=true
+        {{- end }}
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
When the certificate policy controller is running on an older version of
Kubernetes such as OCP 3.11, the lease API is not available. This means
that the legacy approach of leader election is required, which uses
ConfigMaps.

Resolves:
https://github.com/open-cluster-management/backlog/issues/17663