### PR TITLE
Add liveness and readiness probes to GRC

### DIFF
--- a/helm-charts/policy/templates/policy_framework_deployment.yaml
+++ b/helm-charts/policy/templates/policy_framework_deployment.yaml
@@ -70,8 +70,18 @@ spec:
           {{- end }}
         args:
           - '--hub-cluster-configfile=/var/run/klusterlet/kubeconfig'
-        livenessProbe: null
-        readinessProbe: null
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          failureThreshold: 3
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          failureThreshold: 3
+          periodSeconds: 10
         volumeMounts:
           - name: klusterlet-config
             mountPath: /var/run/klusterlet
@@ -110,8 +120,18 @@ spec:
           - name: NO_PROXY
             value: {{ .Values.global.proxyConfig.NO_PROXY }}
           {{- end }}
-        livenessProbe: null
-        readinessProbe: null
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          failureThreshold: 3
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          failureThreshold: 3
+          periodSeconds: 10
         volumeMounts:
           - name: klusterlet-config
             mountPath: /var/run/klusterlet


### PR DESCRIPTION
Add liveness and readiness probe to proactively restart the containers when
hub kubeconfig is changed. This is necessary for backup and restore scenario.

For issue: open-cluster-management/backlog#17651

Signed-off-by: Yu Cao <ycao@redhat.com>