### PR TITLE
Add new Appsub status crd

### DIFF
--- a/helm-charts/application-manager/templates/apps.open-cluster-management.io_subscriptionstatuses_crd.yaml
+++ b/helm-charts/application-manager/templates/apps.open-cluster-management.io_subscriptionstatuses_crd.yaml
@@ -1,0 +1,133 @@
+# Copyright Contributors to the Open Cluster Management project
+
+{{- if not (or (.Capabilities.APIVersions.Has "operator.open-cluster-management.io/v1/MultiClusterHub") (.Capabilities.APIVersions.Has "operator.open-cluster-management.io/v1beta1/MultiClusterHub")) }}
+{{- if semverCompare "< 1.16.0" .Capabilities.KubeVersion.Version }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: subscriptionstatuses.apps.open-cluster-management.io
+spec:
+  group: apps.open-cluster-management.io
+  names:
+    kind: SubscriptionStatus
+    listKind: SubscriptionStatusList
+    plural: subscriptionstatuses
+    shortNames:
+    - appsubstatus
+    singular: subscriptionstatus
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: SubscriptionStatus defines the status of package deployments
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        statuses:
+          description: Statuses represents all the resources deployed by the subscription per cluster
+          properties:
+            packages:
+              items:
+                description: SubscriptionUnitStatus defines status of a package deployment.
+                properties:
+                  apiVersion:
+                    type: string
+                  kind:
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  phase:
+                    description: PackagePhase defines the phasing of a Package
+                    type: string
+                required:
+                - lastUpdateTime
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+{{ else }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: subscriptionstatuses.apps.open-cluster-management.io
+spec:
+  group: apps.open-cluster-management.io
+  names:
+    kind: SubscriptionStatus
+    listKind: SubscriptionStatusList
+    plural: subscriptionstatuses
+    shortNames:
+    - appsubstatus
+    singular: subscriptionstatus
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SubscriptionStatus defines the status of package deployments
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          statuses:
+            description: Statuses represents all the resources deployed by the subscription per cluster
+            properties:
+              packages:
+                items:
+                  description: SubscriptionUnitStatus defines status of a package deployment.
+                  properties:
+                    apiVersion:
+                      type: string
+                    kind:
+                      type: string
+                    lastUpdateTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    phase:
+                      description: PackagePhase defines the phasing of a Package
+                      type: string
+                  required:
+                  - lastUpdateTime
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}
+{{- end }}

--- a/helm-charts/application-manager/templates/apps.open-cluster-management.io_subscriptionstatuses_crd.yaml
+++ b/helm-charts/application-manager/templates/apps.open-cluster-management.io_subscriptionstatuses_crd.yaml
@@ -68,9 +68,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
-  creationTimestamp: null
   name: subscriptionstatuses.apps.open-cluster-management.io
 spec:
   group: apps.open-cluster-management.io

--- a/helm-charts/application-manager/templates/cluster_role_admin.yaml
+++ b/helm-charts/application-manager/templates/cluster_role_admin.yaml
@@ -1,0 +1,15 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregate-appsub-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups:
+  - apps.open-cluster-management.io
+  resources:
+  - subscriptions
+  verbs:
+  - '*'


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

for ACM 2.5Two resources are required to deploy to managed clusters 
1. deploy the new subscriptionStatus CRD to managed cluster
2.  aggregate the apps.open-cluster-management.io.subscription api admin role to cluster admin user. Since the manifest work service account is cluster admin. It will allow the manifest work controller to deploy the  subscription CRs to managed clusters.