### PR TITLE
Backport the spec.copyPolicyMetadata field for 2.6

### DIFF
--- a/helm-charts/policy/templates/policy.open-cluster-management.io_policies_crd.yaml
+++ b/helm-charts/policy/templates/policy.open-cluster-management.io_policies_crd.yaml
@@ -39,6 +39,12 @@ spec:
         spec:
           description: PolicySpec defines the desired state of Policy
           properties:
+            copyPolicyMetadata:
+              description: If set to true (default), all the policy's labels and
+                annotations will be copied to the replicated policy. If set to false,
+                only the policy framework specific policy labels and annotations
+                will be copied to the replicated policy.
+              type: boolean
             disabled:
               type: boolean
             policy-templates:
@@ -190,6 +196,12 @@ spec:
           spec:
             description: PolicySpec defines the desired state of Policy
             properties:
+              copyPolicyMetadata:
+                description: If set to true (default), all the policy's labels and
+                  annotations will be copied to the replicated policy. If set to false,
+                  only the policy framework specific policy labels and annotations
+                  will be copied to the replicated policy.
+                type: boolean
               disabled:
                 type: boolean
               policy-templates:


### PR DESCRIPTION
**This commit will be reverted once CICD has created a hotfix image build**

This will be used for a hotfix image but it will not be officially released to all users.

Relates:
https://issues.redhat.com/browse/ACM-1690